### PR TITLE
Support compiling against gd that was not built with WebP support

### DIFF
--- a/c_src/eimp.c
+++ b/c_src/eimp.c
@@ -51,7 +51,11 @@ uint16_t __le16toh(uint16_t x)
 
 int is_known(char format)
 {
-  return format == PNG || format == JPEG || format == WEBP || format == GIF;
+  return format == PNG || format == JPEG ||
+#ifdef HAVE_WEBP
+ format == WEBP ||
+#endif
+ format == GIF;
 }
 
 /*
@@ -158,8 +162,10 @@ int check_header(uint8_t format, uint8_t *buf, size_t size, size_t *width, size_
     return check_png_header(buf, size, width, height);
   case JPEG:
     return check_jpeg_header(buf, size, width, height);
+#ifdef HAVE_WEBP
   case WEBP:
     return check_webp_header(buf, size, width, height);
+#endif
   case GIF:
     return check_gif_header(buf, size, width, height);
   default:
@@ -170,8 +176,10 @@ int check_header(uint8_t format, uint8_t *buf, size_t size, size_t *width, size_
 gdImagePtr decode(uint8_t format, uint8_t *buf, size_t size)
 {
   switch (format) {
+#ifdef HAVE_WEBP
   case WEBP:
     return gdImageCreateFromWebpPtr(size, buf);
+#endif
   case PNG:
     return gdImageCreateFromPngPtr(size, buf);
   case JPEG:
@@ -186,8 +194,10 @@ gdImagePtr decode(uint8_t format, uint8_t *buf, size_t size)
 void *encode(uint8_t format, gdImagePtr im, int *size)
 {
   switch (format) {
+#ifdef HAVE_WEBP
   case WEBP:
     return gdImageWebpPtr(im, size);
+#endif
   case PNG:
     return gdImagePngPtr(im, size);
   case JPEG:

--- a/configure.ac
+++ b/configure.ac
@@ -39,8 +39,8 @@ AC_CHECK_HEADERS([webp/decode.h], [], [
 
 AC_SEARCH_LIBS([gdImageCreate], [gd], [], [
     AC_MSG_ERROR([libgd library was not found])])
-AC_SEARCH_LIBS([gdImageCreateFromWebpPtr, gdImageWebpPtr], [gd], [], [
-    AC_MSG_ERROR([libgd library is not compiled with WebP support])])
+AC_SEARCH_LIBS([gdImageCreateFromWebpPtr, gdImageWebpPtr], [gd], [AC_DEFINE(HAVE_WEBP, 1, [Define if we have WebP enabled gd])], [
+    AC_MSG_WARN([libgd library is not compiled with WebP support])])
 AC_SEARCH_LIBS([gdImageCreateFromPngPtr, gdImagePngPtr], [gd], [], [
     AC_MSG_ERROR([libgd library is not compiled with PNG support])])
 AC_SEARCH_LIBS([gdImageCreateFromJpegPtr, gdImageJpegPtr], [gd], [], [


### PR DESCRIPTION
The gd library included with Red Hat Enterprise Linux 7 & CentOS 7 is not built with WebP support, causing eimp compilation to fail. This PR makes that support optional, at the cost of losing WebP support in eimp.