### PR TITLE
Don't link to libdl on NetBSD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
 
 {port_env, [{"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
             {"CFLAGS", "$CFLAGS"},
-            {"^((?!openbsd).)*$", "LDFLAGS", "$LDFLAGS -ldl"},
+            {"^((?!(net|open)bsd).)*$", "LDFLAGS", "$LDFLAGS -ldl"},
             {"LDFLAGS", "$LDFLAGS"}]}.
 
 {port_specs, [{"priv/bin/eimp", ["c_src/eimp.c"]}]}.


### PR DESCRIPTION
I'm not sure that my regular expression is correct since I'm not familiar with rebar. But it fixes the build error with libdl on NetBSD.